### PR TITLE
Change hrp to humanReadablePrefix

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require('assert');
+const bech32 = require('./bech32');
+
+// decode
+const addr = 'bc1qkg62ae0wwntkzhq8td87s87c4nj5zdlj2ga8j7';
+const {version, program} = bech32.decode('bc', addr);
+assert.strictEqual(version, 0);
+assert.strictEqual(
+  Buffer.from(program).toString('hex'),
+  'b234aee5ee74d7615c075b4fe81fd8ace54137f2');
+
+// encode
+const pubKeyHash = Buffer.from(
+  '8bf743f3fd7f46804c39711af735b121747ef6b4',
+  'hex');
+assert.strictEqual(
+  bech32.encode('bc', 0, pubKeyHash),
+  'bc1q30m58ula0argqnpewyd0wdd3y968aa457pksa3');
+
+console.log('OK');


### PR DESCRIPTION
This PR changes most of the occurrences of `hrp` to `humanReadablePrefix`. Did I violate any max length code conventions here? I don't have any kind of auto format rules turned on.

Doing so addresses https://github.com/saving-satoshi/challenges/issues/9

It feels silly to go out of the way to make a PR for this but because this code is for educational purposes, and because we're asking players to go through and identify the function that they need for the challenge, I think more obvious variable names can go a long way. Note that I did not change every occurrence of "hrp". I left it as-is for function names and properties on return objects.